### PR TITLE
Enhance client_id extraction with additional regex

### DIFF
--- a/o365enum.py
+++ b/o365enum.py
@@ -106,7 +106,10 @@ def o365enum_office(usernames):
         headers=headers
     )
     # we get the application identifier and session identifier
-    client_id = re.findall(b'"appId":"([^"]*)"', response.content)
+    client_id = (
+        re.findall(b'"appId":"([^"]*)"', response.content) or
+        re.findall(b"appId:\\s*\\'([^\\']+)\\'", response.content)
+    )
     # then we request the /login page which will redirect us to the authorize
     # flow
     response = session.get(


### PR DESCRIPTION
The office.com method was raising 'An error occured when generating headers' because appid place got changed. The appId is now embedded inside the aadConfig JS object as:
```js
aadConfig: { replyUri: \'https://www.office.com/\', host: \'login.microsoftonline.com\', appId: \'...-...\' } ...
```
<img width="834" height="239" alt="image" src="https://github.com/user-attachments/assets/f256567c-80d8-4494-b880-0c01888820fb" />

The suggested fix now just adds a fallback regex for the current format.